### PR TITLE
Set Cache-Control max-age to same value as Expires

### DIFF
--- a/all/s3_staticfiles_django.md
+++ b/all/s3_staticfiles_django.md
@@ -115,12 +115,13 @@ Using Amazon Web Services (AWS) S3 For storing static and media files for a Djan
 
 		import datetime
 
-		date_two_months_later = datetime.date.today() + datetime.timedelta(2 * 365 / 12) 
+                two_months = datetime.timedelta(days=61)
+		date_two_months_later = datetime.date.today() + two_months
 		expires = date_two_months_later.strftime("%A, %d %B %Y 20:00:00 GMT")
 
 		AWS_HEADERS = { 
 			'Expires': expires,
-			'Cache-Control': 'max-age=86400',
+			'Cache-Control': 'max-age=%d' % (int(two_months.total_seconds()), ),
 		}
 		```
 

--- a/all/s3_staticfiles_django.md
+++ b/all/s3_staticfiles_django.md
@@ -115,7 +115,7 @@ Using Amazon Web Services (AWS) S3 For storing static and media files for a Djan
 
 		import datetime
 
-                two_months = datetime.timedelta(days=61)
+		two_months = datetime.timedelta(days=61)
 		date_two_months_later = datetime.date.today() + two_months
 		expires = date_two_months_later.strftime("%A, %d %B %Y 20:00:00 GMT")
 


### PR DESCRIPTION
In modern browsers, `Cache-Control` takes precedence over `Expires`.
So this example code currently recommends people set headers that cause
most browsers to discard changes after a day rather than after 2 months as
the text suggests.

This change unifies the `Expires` and `Cache-Control` headers so that they
both derive their values from a single variable indicating the desired cache
time.